### PR TITLE
fix display error message on handleEvent failure

### DIFF
--- a/lib/Operation/ConvertMediaOperation.php
+++ b/lib/Operation/ConvertMediaOperation.php
@@ -57,7 +57,7 @@ class ConvertMediaOperation implements ISpecificOperation {
 		try {
 			$this->handleEvent($eventName, $event, $ruleMatcher);
 		} catch (\Throwable $e) {
-			$this->logger->error("({$e->getCode()}) :: $e->getMessage()", ['eventName' => $eventName]);
+			$this->logger->error("({$e->getCode()}) :: {$e->getMessage()}", ['eventName' => $eventName]);
 		}
 	}
 


### PR DESCRIPTION
This fix the error "Undefined property: TypeError::$getMessage at" when an error is catched in this line