### PR TITLE
Fix: Propagate nonce properly to loaded script

### DIFF
--- a/src/personalSettings.js
+++ b/src/personalSettings.js
@@ -2,6 +2,10 @@ import Vue from 'vue'
 import './bootstrap.js'
 import PersonalSettings from './views/PersonalSettings.vue'
 
+// CSP config for webpack dynamic chunk loading
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(OC.requestToken)
+
 new Vue({ // eslint-disable-line no-new
 	el: '#workflow_media_converter-personalSettings',
 	render: h => h(PersonalSettings),


### PR DESCRIPTION
Resolves #409

It seems we only need to tell webpack to do it with a oneliner: https://webpack.js.org/guides/csp/

We just do what NC's Markdown editor does:
https://github.com/nextcloud/richdocuments/blob/ccdd7fcb52857225784cf686373253a2b6ea539a/src/admin.js#L10