### PR TITLE
Construct a name for the jobs in the settings

### DIFF
--- a/src/components/DisplayConversionBatch.vue
+++ b/src/components/DisplayConversionBatch.vue
@@ -1,5 +1,8 @@
 <template>
 	<div class="wmc-display-conversion-batch">
+		<div class="wmc-display-conversion-batch__label">
+			{{ conversionBatch.sourceFolder }} *.{{ conversionBatch.sourceExtension }} &#8594; {{ conversionBatch.postConversionOutputRuleMoveFolder }} *.{{ conversionBatch.outputExtension }}
+		</div>
 		<div class="wmc-display-conversion-batch__status-container">
 			<div class="wmc-display-conversion-batch__status">
 				<StatusBadge :status="conversionBatch.status" />


### PR DESCRIPTION
Having multiple jobs configured can get easily confusing, so we try to make clear which is which.

There's probably more to it on the CSS side but at least it makes it clear for me.