### PR TITLE
Fix Undefined variable $node for GenericEvent

### DIFF
--- a/lib/Operation/ConvertMediaOperation.php
+++ b/lib/Operation/ConvertMediaOperation.php
@@ -73,6 +73,12 @@ class ConvertMediaOperation implements ISpecificOperation {
 			}
 
 			$node = $node[0];
+		} elseif  ($event instanceof \OCP\EventDispatcher\GenericEvent) {
+			if ($event->getSubject() instanceof \OC\Files\Node\File) {
+				$node = $event->getSubject();
+			} else {
+				return;
+			}
 		}
 
 		$path = $node->getPath();


### PR DESCRIPTION
I am not even PHP developer, but that is a quick fix for  Undefined variable $node #429 issue that I was facing too (I am not the author of the issue). This simple extra condition fixed it.
I don't know if the other conditions should be changed, or not.