### PR TITLE
Fix conversion batches requiring admin account

### DIFF
--- a/lib/Controller/ConversionBatchesController.php
+++ b/lib/Controller/ConversionBatchesController.php
@@ -32,10 +32,12 @@ class ConversionBatchesController extends Controller {
 		$this->connection = $connection;
 	}
 
+	#[NoAdminRequired]
 	public function index(): DataResponse {
 		return new DataResponse($this->getConversionBatches());
 	}
 
+	#[NoAdminRequired]
 	public function show($id): DataResponse {
 		$conversionBatches = $this->getConversionBatches();
 
@@ -48,6 +50,7 @@ class ConversionBatchesController extends Controller {
 		return new DataResponse($conversionBatches[$index]);
 	}
 
+	#[NoAdminRequired]
 	public function create(array $batch): DataResponse {
 		$conversionBatches = $this->getConversionBatches();
 
@@ -66,6 +69,7 @@ class ConversionBatchesController extends Controller {
 		return new DataResponse($batch, Http::STATUS_CREATED);
 	}
 
+	#[NoAdminRequired]
 	public function delete($id): DataResponse {
 		$this->cancelPendingConversionsForBatch($id);
 

--- a/lib/Controller/PersonalSettingsController.php
+++ b/lib/Controller/PersonalSettingsController.php
@@ -17,10 +17,12 @@ class PersonalSettingsController extends Controller {
 		$this->configService = $configService;
 	}
 
+    #[NoAdminRequired]
 	public function getSettings(): DataResponse {
 		return new DataResponse($this->configService->getCurrentUserConfig());
 	}
 
+    #[NoAdminRequired]
 	public function updateSettings(array $values): DataResponse {
 		$this->configService->setConfig($values);
 


### PR DESCRIPTION
This _actually_ fixes #459 for Nextcloud 30 and above. Turns out Nextcloud only recognizes the attribute on methods, not entire classes.
