### PR TITLE
Fix copying of source file creation time

### DIFF
--- a/lib/BackgroundJobs/ConvertMediaJob.php
+++ b/lib/BackgroundJobs/ConvertMediaJob.php
@@ -224,9 +224,9 @@ class ConvertMediaJob extends QueuedJob {
 	}
 
 	public function handlePostConversion() {
-		$this->handlePostConversionSourceFile();
-
 		$this->writePostConversionOutputFile();
+		
+		$this->handlePostConversionSourceFile();
 
 		return $this;
 	}


### PR DESCRIPTION
This MR addresses issue #538 

The problem was that the time stamp of the source file was read after it was already deleted resulting in a file not found exception.